### PR TITLE
Add serialised save/load functionality with browser cookies

### DIFF
--- a/assets/js/main.js
+++ b/assets/js/main.js
@@ -1,27 +1,5 @@
 let citations = []
 
-function setCookie(cname, cvalue, exdays) {
-    var d = new Date();
-    d.setTime(d.getTime() + (exdays*24*60*60*1000));
-    var expires = "expires="+ d.toUTCString();
-    document.cookie = cname + "=" + cvalue + ";" + expires + ";path=/";
-}
-
-function getCookie(cname) {
-    var name = cname + "=";
-    var decodedCookie = decodeURIComponent(document.cookie);
-    var ca = decodedCookie.split(';');
-    for(var i = 0; i <ca.length; i++) {
-        var c = ca[i];
-        while (c.charAt(0) == ' ') {
-            c = c.substring(1);
-        }
-        if (c.indexOf(name) == 0) {
-            return c.substring(name.length, c.length);
-        }
-    }
-    return "";
-}
 function htmlEscape(str) {
     return str
         .replace(/&/g, '&amp;')
@@ -72,7 +50,7 @@ function constructCitationFromObj(obj){//Converts object to web citation
 function updateCitationList() {
     var data = {data: citations} //Wrap citations in object
     var serialized = jQuery.param(data);//Serialize...
-    setCookie("cites", serialized,120);//Add to cookies
+    Cookies.set("cites", serialized);//Add to cookies
     let newCitationListHTML = ""
     citations.forEach(element => {
         newCitationListHTML += `<li> ${element.citationHTML} </li>
@@ -105,8 +83,8 @@ function loadCitationParamString(data){//Loads citation from jQuery.param functi
     updateCitationList();//Update citation list to display loaded citations
 }
 //Load citations from cookies (if cookies exist)
-if(getCookie("cites") != ""){
-    loadCitationParamString(getCookie("cites"));
+if(Cookies.get("cites") != undefined){
+    loadCitationParamString(Cookies.get("cites"));
 }
 
 $(  // only start when DOM ready

--- a/assets/js/main.js
+++ b/assets/js/main.js
@@ -1,7 +1,31 @@
 let citations = []
 
+function setCookie(cname, cvalue, exdays) {
+    var d = new Date();
+    d.setTime(d.getTime() + (exdays*24*60*60*1000));
+    var expires = "expires="+ d.toUTCString();
+    document.cookie = cname + "=" + cvalue + ";" + expires + ";path=/";
+}
+//Function to reverse parameter
+function deparam(params,coerce){var obj={},coerce_types={'true':!0,'false':!1,'null':null};$.each(params.replace(/\+/g,' ').split('&'),function(j,v){var param=v.split('='),key=decodeURIComponent(param[0]),val,cur=obj,i=0,keys=key.split(']['),keys_last=keys.length-1;if(/\[/.test(keys[0])&&/\]$/.test(keys[keys_last])){keys[keys_last]=keys[keys_last].replace(/\]$/,'');keys=keys.shift().split('[').concat(keys);keys_last=keys.length-1}else{keys_last=0}if(param.length===2){val=decodeURIComponent(param[1]);if(coerce){val=val&&!isNaN(val)?+val:val==='undefined'?undefined:coerce_types[val]!==undefined?coerce_types[val]:val}if(keys_last){for(;i<=keys_last;i++){key=keys[i]===''?cur.length:keys[i];cur=cur[key]=i<keys_last?cur[key]||(keys[i+1]&&isNaN(keys[i+1])?{}:[]):val}}else{if($.isArray(obj[key])){obj[key].push(val)}else if(obj[key]!==undefined){obj[key]=[obj[key],val]}else{obj[key]=val}}}else if(key){obj[key]=coerce?undefined:''}});return obj}
+
+function getCookie(cname) {
+    var name = cname + "=";
+    var decodedCookie = decodeURIComponent(document.cookie);
+    var ca = decodedCookie.split(';');
+    for(var i = 0; i <ca.length; i++) {
+        var c = ca[i];
+        while (c.charAt(0) == ' ') {
+            c = c.substring(1);
+        }
+        if (c.indexOf(name) == 0) {
+            return c.substring(name.length, c.length);
+        }
+    }
+    return "";
+}
 function htmlEscape(str) {
-    return str 
+    return str
         .replace(/&/g, '&amp;')
         .replace(/"/g, '&quot;')
         .replace(/'/g, '&#39;')
@@ -43,14 +67,21 @@ ${this.datePublished}, ${this.dateAccessed}, <a href="http://${this.url}">${this
   }
 }
 
+function constructCitationFromObj(obj){//Converts object to web citation
+    return new WebCitation(obj.authorLast,obj.authorFirst,obj.pageTitle,obj.siteTitle,obj.datePublished,obj.dateAccessed,obj.url);
+}
 
 function updateCitationList() {
+    var data = {data: citations} //Wrap citations in object
+    var serialized = jQuery.param(data);//Serialize...
+    setCookie("cites", serialized,120);//Add to cookies
     let newCitationListHTML = ""
     citations.forEach(element => {
         newCitationListHTML += `<li> ${element.citationHTML} </li>
 `
     })
     $("#citationList").html(newCitationListHTML)
+
 }
 
 function resetCitationList() {
@@ -62,12 +93,24 @@ function resetCitationList() {
 function getMLADate(year, month, day) {
     let date = new Date(year, month - 1, day)
     return date.toLocaleDateString(
-        "en-GB", 
+        "en-GB",
         dateFormat = {day: "numeric", month: "long", year: "numeric"}
     )
 }
 
+//Load citations from cookies (if cookies exist)
+if(getCookie("cites") != ""){
+    var data = getCookie("cites");
+    var data = deparam(data)["data"];//Reverse the serialization, returns an array of objects
+    for(var i in data){//Convert each object to webcitation, push into citation
+        citations.push(constructCitationFromObj(data[i]));
+    }
+
+    updateCitationList();//Update citation list to display loaded citations
+}
+
 $(  // only start when DOM ready
+
     $("#submitButton").on("click", event => {
         event.preventDefault()
         // Handle dates

--- a/assets/js/main.js
+++ b/assets/js/main.js
@@ -6,8 +6,6 @@ function setCookie(cname, cvalue, exdays) {
     var expires = "expires="+ d.toUTCString();
     document.cookie = cname + "=" + cvalue + ";" + expires + ";path=/";
 }
-//Function to reverse parameter
-function deparam(params,coerce){var obj={},coerce_types={'true':!0,'false':!1,'null':null};$.each(params.replace(/\+/g,' ').split('&'),function(j,v){var param=v.split('='),key=decodeURIComponent(param[0]),val,cur=obj,i=0,keys=key.split(']['),keys_last=keys.length-1;if(/\[/.test(keys[0])&&/\]$/.test(keys[keys_last])){keys[keys_last]=keys[keys_last].replace(/\]$/,'');keys=keys.shift().split('[').concat(keys);keys_last=keys.length-1}else{keys_last=0}if(param.length===2){val=decodeURIComponent(param[1]);if(coerce){val=val&&!isNaN(val)?+val:val==='undefined'?undefined:coerce_types[val]!==undefined?coerce_types[val]:val}if(keys_last){for(;i<=keys_last;i++){key=keys[i]===''?cur.length:keys[i];cur=cur[key]=i<keys_last?cur[key]||(keys[i+1]&&isNaN(keys[i+1])?{}:[]):val}}else{if($.isArray(obj[key])){obj[key].push(val)}else if(obj[key]!==undefined){obj[key]=[obj[key],val]}else{obj[key]=val}}}else if(key){obj[key]=coerce?undefined:''}});return obj}
 
 function getCookie(cname) {
     var name = cname + "=";

--- a/assets/js/main.js
+++ b/assets/js/main.js
@@ -98,15 +98,17 @@ function getMLADate(year, month, day) {
     )
 }
 
-//Load citations from cookies (if cookies exist)
-if(getCookie("cites") != ""){
-    var data = getCookie("cites");
+function loadCitationParamString(data){//Loads citation from jQuery.param function
     var data = deparam(data)["data"];//Reverse the serialization, returns an array of objects
     for(var i in data){//Convert each object to webcitation, push into citation
         citations.push(constructCitationFromObj(data[i]));
     }
 
     updateCitationList();//Update citation list to display loaded citations
+}
+//Load citations from cookies (if cookies exist)
+if(getCookie("cites") != ""){
+    loadCitationParamString(getCookie("cites"));
 }
 
 $(  // only start when DOM ready

--- a/index.html
+++ b/index.html
@@ -107,7 +107,10 @@
         </div>
     </body>
 
-
+    <!-- Deparam -->
+    <script src="https://cdn.jsdelivr.net/gh/il8677/jquery-additions/deparam.js" charset="utf-8"></script>
+    <!-- jscookie -->
+    <script src="https://cdn.jsdelivr.net/npm/js-cookie@2/src/js.cookie.min.js"></script>
     <!-- jQuery -->
     <script
         src="https://code.jquery.com/jquery-3.3.1.min.js"

--- a/index.html
+++ b/index.html
@@ -1,22 +1,22 @@
 <!DOCTYPE html>
 <html>
-    
-    
+
+
     <head>
         <meta charset="utf-8" />
         <title>SMCite</title>
         <!-- Bootstrap -->
-            <link 
+            <link
                     rel="stylesheet"
-                    href="//stackpath.bootstrapcdn.com/bootstrap/4.1.3/css/bootstrap.min.css" 
-                    integrity="sha384-MCw98/SFnGE8fJT3GXwEOngsV7Zt27NXFoaoApmYm81iuXoPkFOJwJ8ERdknLPMO" 
+                    href="http://stackpath.bootstrapcdn.com/bootstrap/4.1.3/css/bootstrap.min.css"
+                    integrity="sha384-MCw98/SFnGE8fJT3GXwEOngsV7Zt27NXFoaoApmYm81iuXoPkFOJwJ8ERdknLPMO"
                     crossorigin="anonymous" />
             <script
-                    src="//stackpath.bootstrapcdn.com/bootstrap/4.1.3/js/bootstrap.min.js" 
-                    integrity="sha384-ChfqqxuZUCnJSK3+MXmPNIyE6ZbWh2IMqE241rYiqJxyMiZ6OW/JmZQ5stwEULTy" 
+                    src="http://stackpath.bootstrapcdn.com/bootstrap/4.1.3/js/bootstrap.min.js"
+                    integrity="sha384-ChfqqxuZUCnJSK3+MXmPNIyE6ZbWh2IMqE241rYiqJxyMiZ6OW/JmZQ5stwEULTy"
                     crossorigin="anonymous"></script>
         <!-- Font Awesome -->
-        <link 
+        <link
               rel="stylesheet"
               href="https://use.fontawesome.com/releases/v5.4.1/css/all.css"
               integrity="sha384-5sAR7xN1Nv6T6+dT2mhtzEpVJvfS3NScPQTrOxhwjIuvcA67KV2R5Jz6kr4abQsz"
@@ -24,8 +24,8 @@
         <!-- Custom CSS Styling -->
         <link rel="stylesheet" href="assets/css/style.css" type="text/css" />
     </head>
-    
-    
+
+
     <body>
         <div id="container">
             <div id="header">
@@ -46,13 +46,13 @@
                 <div>
                     <h4>Create a Citation</h4>
                     <form id="creationForm">
-                        
+
                         <label for="authorFirst">Author:</label>
                         <div class="input-group">
                             <input type="text" placeholder="First (given)" id="authorFirst" class="form-control" />
                             <input type="text" placeholder="Last (family)" id="authorLast" class="form-control" />
                         </div>
-                        
+
                         <label for="authorFirst">Page:</label>
                         <input type="text" placeholder="Page or article title" id="pageTitle" class="form-control" />
                         <input type="text" placeholder="Website title" id="siteTitle" class="form-control" />
@@ -62,7 +62,7 @@
                             </div>
                             <input type="text" placeholder="Page URL" id="manualCiteURL" class="form-control" />
                         </div>
-                        
+
                         <label for="">Dates:</label>
                         <div class="input-group">
                             <div class="input-group-prepend">
@@ -106,8 +106,8 @@
             </div>
         </div>
     </body>
-    
-    
+
+
     <!-- jQuery -->
     <script
         src="https://code.jquery.com/jquery-3.3.1.min.js"


### PR DESCRIPTION
Added functionality for serialisation. The citations will now be saved as a string in the cookies and loaded again when the page is reloaded. This also allows further functionality when the serialised string can be sent to a server for user-based citation saving instead of just temporary machine based citation saving. 